### PR TITLE
show help on no args instead of error

### DIFF
--- a/tginow
+++ b/tginow
@@ -433,6 +433,11 @@ main() {
     check_aws_config
     check_aws_sso
 
+    if [ $# -eq 0 ]; then
+        usage
+        exit 1
+    fi
+
     case "$1" in
     status)
         # TODO: improve how the output is displayed


### PR DESCRIPTION
before:
```
❯ ./tginow    
🚀 TGI Devbox CLI Tool
./tginow: line 441: $1: unbound variable
```

after:
```
❯ ./tginow    
🚀 TGI Devbox CLI Tool
Usage: ./tginow <command> [options]
Commands:
  status          Get the status of the devbox
  up              Create and setup a new devbox
  open            Open a byobu session with three panes
  ssh             SSH into the devbox
  down            Shutdown the devbox
  help            Display this help message
```